### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+indexed-gzip (0.8.6-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:58:19 +0100
+
 indexed-gzip (0.8.6-1) unstable; urgency=medium
 
   * Fresh upstream version, dropping CPed patches

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Build-Depends: debhelper (>= 9),
 Standards-Version: 3.9.8
 Homepage: https://github.com/pauldmccarthy/indexed_gzip
 Vcs-Browser: https://github.com/neurodebian/indexed_gzip
-Vcs-Git: git://github.com/neurodebian/indexed_gzip -b debian
+Vcs-Git: https://github.com/neurodebian/indexed_gzip -b debian
 X-Python-Version: >= 2.7
 
 Package: python-indexed-gzip


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
