### PR TITLE
Remove unnecessary 'Testsuite: autopkgtest' header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+indexed-gzip (0.8.6-2) UNRELEASED; urgency=medium
+
+  * Remove unnecessary 'Testsuite: autopkgtest' header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:58:37 +0100
+
 indexed-gzip (0.8.6-1) unstable; urgency=medium
 
   * Fresh upstream version, dropping CPed patches

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Uploaders: Michael Hanke <mih@debian.org>,
            Alex Waite <Alexqw85@gmail.com>,
            Yaroslav Halchenko <debian@onerussian.com>,
 Section: python
-Testsuite: autopkgtest
 Priority: optional
 Build-Depends: debhelper (>= 9),
                zlib1g-dev,


### PR DESCRIPTION
Remove unnecessary 'Testsuite: autopkgtest' header.

Fixes lintian: unnecessary-testsuite-autopkgtest-field
See https://lintian.debian.org/tags/unnecessary-testsuite-autopkgtest-field.html for more details.
